### PR TITLE
fix: incorrect loglevel variable naming used

### DIFF
--- a/docker/standalone/config.yaml
+++ b/docker/standalone/config.yaml
@@ -47,7 +47,7 @@ exporters:
     tls:
       insecure: true
   logging:
-    logLevel: debug
+    loglevel: debug
 service:
   telemetry:
     metrics:


### PR DESCRIPTION
fixes: https://github.com/SigNoz/signoz.io/issues/822