### PR TITLE
fix: remove `pprof` from use as it is not defined

### DIFF
--- a/docker/standalone/config.yaml
+++ b/docker/standalone/config.yaml
@@ -52,7 +52,7 @@ service:
   telemetry:
     metrics:
       address: 0.0.0.0:8888
-  extensions: [health_check, pprof, zpages]
+  extensions: [health_check, zpages]
   pipelines:
     metrics:
       receivers: [otlp]


### PR DESCRIPTION
fixes: https://github.com/SigNoz/signoz.io/issues/822